### PR TITLE
Add ThinProduct and ThinProductList for optimized product fetching

### DIFF
--- a/app/src/lib/data/products.ts
+++ b/app/src/lib/data/products.ts
@@ -1,0 +1,44 @@
+import { Product, ProductList, ThinProduct, ThinProductList } from "../types";
+const baseURI = 'https://dummyjson.com/products/';
+
+
+export const getProduct = async (id: number): Promise<Product> => {
+    try {
+        const response = await fetch(`${baseURI}${id}`);
+        return await response.json() as Product;
+    } catch (e) {
+        throw (e);
+    }
+}
+
+
+
+export const getProducts = async (): Promise<ThinProduct[]> => {
+    const filter = '?select=title,price,discountPercentage,thumbnail,rating,availabilityStatus';
+    const categories = ['smartphones', 'tablets', 'mobile-accessories', 'laptops'];
+    const filterURIS = categories.map(categoryName => `${baseURI}category/${categoryName}${filter}`)
+
+    try {
+        const tasks = filterURIS.map(async uri => {
+            return new Promise<ThinProductList>((resolve, reject) => {
+                setTimeout(async () => {
+                    const request = await fetch(uri);
+                    const list = await request.json() as ThinProductList;
+                    resolve(list);
+                }, 100);
+            });
+        });
+
+        const data = await Promise.all(tasks);
+        return data.reduce((accumulator, currentValue) => {
+            return { ...accumulator, products: accumulator.products.concat(currentValue.products) }
+        }).products;
+    } catch (e) {
+        throw (e);
+    }
+}
+
+// 'https://dummyjson.com/products/category/smartphones/?select=title,price,discountPercentage,thumbnail,rating,availabilityStatus'
+// 'https://dummyjson.com/products/category/tablets/?select=title,price,discountPercentage,thumbnail,rating,availabilityStatus'
+// 'https://dummyjson.com/products/category/mobile-accessories/?select=title,price,discountPercentage,thumbnail,rating,availabilityStatus'
+// 'https://dummyjson.com/products/category/laptops/?select=title,price,discountPercentage,thumbnail,rating,availabilityStatus'

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -1,8 +1,24 @@
-export interface Root {
+export interface ProductList {
   products: Product[]
   total: number
   skip: number
   limit: number
+}
+
+export interface ThinProductList {
+  products: ThinProduct[]
+  total: number
+  skip: number
+  limit: number
+}
+
+export interface ThinProduct {
+  id: number
+  title: string
+  discountPercentage: number
+  thumbnail: string
+  rating: number
+  availabilityStatus: string
 }
 
 export interface Product {


### PR DESCRIPTION
Introduce ThinProduct and ThinProductList to streamline data retrieval when listing products. Implement functions to fetch a single product and a list of products, reducing the amount of data needed.