### PR TITLE
Add ContentGrid component as general page wrapper

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -41,6 +41,19 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+
+  /* content-grid */
+  --content-max-width: 80rem;
+  --breakout-max-width: 85rem;
+  --padding-inline: 1rem;
+  --breakout-size: calc(
+    (var(--breakout-max-width) - var(--content-max-width)) / 2
+  );
+  --grid-cols-content: [full-width-start] minmax(var(--padding-inline), 1fr)
+    [breakout-start] minmax(0, var(--breakout-size)) [content-start]
+    min(100% - (var(--padding-inline) * 2), var(--content-max-width))
+    [content-end] minmax(0, var(--breakout-size)) [breakout-end]
+    minmax(var(--padding-inline), 1fr) [full-width-end];
 }
 
 :root {
@@ -119,4 +132,25 @@
   body {
     @apply bg-background text-foreground;
   }
+}
+
+
+@utility content-grid {
+  display: grid;
+  grid-template-columns: var(--grid-cols-content);
+}
+
+.content-grid > :not(.breakout, .full-width),
+.full-width > :not(.breakout, .full-width) {
+  grid-column: content;
+}
+
+.content-grid > .breakout {
+  grid-column: breakout;
+}
+
+.content-grid > .full-width {
+  grid-column: full-width;
+  display: grid;
+  grid-template-columns: inherit;
 }

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ContentGrid from "@/components/content-grid";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <main>
+          <ContentGrid>{children}</ContentGrid>
+        </main>
       </body>
     </html>
   );

--- a/app/src/components/content-grid.tsx
+++ b/app/src/components/content-grid.tsx
@@ -1,0 +1,7 @@
+export default function ContentGrid({children}:{children: React.ReactNode}) {
+    return (
+        <div className="content-grid">
+            {children}
+        </div>
+    );
+}


### PR DESCRIPTION
Add ContentGrid component for page layout.
Normal sections automatically align to the content column, while breakout and full-width sections can span wider areas.