### PR TITLE
Header responsiveness, improvements & design

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.7",

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -7,6 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-primary-green: var(--primary-green);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -85,7 +86,7 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  --primary-green: #1ABA1A;
+  --primary-green: #2FBF71;
 }
 
 .dark {

--- a/app/src/components/header.tsx
+++ b/app/src/components/header.tsx
@@ -1,73 +1,62 @@
-import logo from "../../public/next.svg";
-import Image from "next/image";
 import Link from "next/link";
-import { Menu } from "lucide-react";
 import {
   NavigationMenu,
   NavigationMenuItem,
   NavigationMenuList,
 } from "./ui/navigation-menu";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
 import { HeaderLink } from "./header/headerlink";
 import HeaderCartButton from "./header/header-cart-button";
 import HeaderUserButton from "./header/header-user-button";
+import HeaderLinkDropdown from "@/components/header/headerlink-dropdown";
+import HeaderMobileMenu from "@/components/header/header-mobile-menu";
+import { NavItem } from "@/lib/types";
+
+const nav: NavItem[] = [
+  {
+    slug: "/products",
+    label: "Products",
+    subcategories: [
+      { label: "Smartphones", slug: "/category/smartphones" },
+      { label: "Tablets", slug: "/category/tablets" },
+      { label: "Mobile Accessories", slug: "/category/mobile-accessories" },
+      { label: "Laptops", slug: "/category/laptops" },
+    ],
+  },
+  { slug: "/about", label: "About" },
+  { slug: "/contact", label: "Contact" },
+];
 
 export default function Header() {
-  const nav = [
-    { slug: [""], label: "Home" },
-    { slug: ["products"], label: "Products" },
-    { slug: ["about"], label: "About" },
-    { slug: ["contact"], label: "Contact" },
-  ];
-
   return (
-    <header className="flex flex-row p-5 justify-start items-center bg-white h-fit">
-      <Image
-        src={logo}
-        width={180}
-        height={38}
-        alt="Site logo"
-        className="mr-10"
-      ></Image>
-      <NavigationMenu className="hidden sm:block">
-        <NavigationMenuList>
-          {nav.map((item, index) => (
-            <NavigationMenuItem key={index}>
-              <HeaderLink href={`/${item.slug[0]}`}>{item.label}</HeaderLink>
-            </NavigationMenuItem>
-          ))}
-        </NavigationMenuList>
-      </NavigationMenu>
-      <section className="ml-auto flex flex-row">
-        <HeaderUserButton />
-        <DropdownMenu>
-          <DropdownMenuTrigger className="sm:hidden px-2 ml-2 rounded-md cursor-pointer data-[state=open]:bg-gray-300">
-            <Menu width={38} height={38} />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="min-w-screen mt-2">
+    <header className="bg-white full-width">
+      <div className="flex items-center">
+        <Link href="/" className="mr-10">
+          <h1 className="text-2xl font-bold py-4">Group 4</h1>
+        </Link>
+
+        <NavigationMenu className="hidden md:block">
+          <NavigationMenuList>
             {nav.map((item, index) => (
-              <DropdownMenuItem
-                key={index}
-                asChild
-                className="rouned-md data-highlighted:bg-gray-300"
-              >
-                <Link
-                  href={`/${item.slug[0]}`}
-                  className="p-4 w-full font-bold text-xl"
-                >
-                  {item.label}
-                </Link>
-              </DropdownMenuItem>
+              <NavigationMenuItem key={index}>
+                {item.subcategories ? (
+                  <HeaderLinkDropdown
+                    label={item.label}
+                    href={item.slug}
+                    subcategories={item.subcategories}
+                  />
+                ) : (
+                  <HeaderLink href={item.slug}>{item.label}</HeaderLink>
+                )}
+              </NavigationMenuItem>
             ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <HeaderCartButton />
-      </section>
+          </NavigationMenuList>
+        </NavigationMenu>
+        <section className="ml-auto flex flex-row gap-2">
+          <HeaderUserButton />
+          <HeaderCartButton />
+          <HeaderMobileMenu nav={nav} />
+        </section>
+      </div>
     </header>
   );
 }

--- a/app/src/components/header/header-cart-button.tsx
+++ b/app/src/components/header/header-cart-button.tsx
@@ -1,115 +1,169 @@
-"use client"
+"use client";
 import {
-    Sheet,
-    SheetContent,
-    SheetDescription,
-    SheetFooter,
-    SheetHeader,
-    SheetTitle,
-    SheetTrigger,
-} from "@/components/ui/sheet"
-import { toast } from "sonner"
-import useLocalStorage from "@/lib/data/local-storage"
-import { ShoppingCartItem } from "@/lib/types"
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { toast } from "sonner";
+import useLocalStorage from "@/lib/data/local-storage";
+import { ShoppingCartItem } from "@/lib/types";
 import Link from "next/link";
+import { ShoppingBasket } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useEffect, useState } from "react";
 
 export default function HeaderCartButton() {
+  const [cart, setCart] = useLocalStorage<ShoppingCartItem[]>(
+    "shopping-cart",
+    []
+  );
 
-    const [cart, setCart] = useLocalStorage<ShoppingCartItem[]>("shopping-cart", []);
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
-    const handleUpdateItemQuantity = (productId: number, quantity: number) => {
-        const updatedCart = cart.map(item => {
-            if (item.product.id === productId) {
-                return { ...item, quantity };
-            }
-            return item;
-        });
-        setCart(updatedCart);
-        toast.success(`Item quantity updated!`);
-    }
+  const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
+  const totalPrice = cart.reduce(
+    (sum, item) => sum + item.product.price * item.quantity,
+    0
+  );
 
-    const handleRemoveFromCart = (productId: number) => {
-        const updatedCart = cart.filter(item => item.product.id !== productId);
-        setCart(updatedCart);
-        toast.success(`Item removed from cart!`);
-    }
-    return (
-        <Sheet>
-            <SheetTrigger>
-                <div className="flex flex-row content-center justify-center mr-2 ml-2 px-4 py-2 text-black rounded-md hover:bg-gray-100 hover:underline cursor-pointer">
-                    <div className="flex flex-col content-center justify-center mr-4 rounded-full bg-gray-200 p-2">
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="30"
-                            height="30"
-                            fill="currentColor"
-                            viewBox="0 0 24 24"
-                            aria-hidden="true"
-                        >
-                            <path d="M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2zm10 0c-1.1 0-1.99.9-1.99 2S15.9 22 17 22s2-.9 2-2-.9-2-2-2zM7.16 16h9.45c.75 0 1.41-.41 1.75-1.03l3.24-6.16A1 1 0 0 0 21.7 7H6.21l-.94-2H2v2h2l3.6 7.59-1.35 2.44C5.16 17.37 5.76 18 6.5 18h12v-2H7.42c-.14 0-.25-.11-.25-.25l.03-.12.9-1.63z" />
-                        </svg>
-                    </div>
+  const handleUpdateItemQuantity = (productId: number, quantity: number) => {
+    const updatedCart = cart.map((item) => {
+      if (item.product.id === productId) {
+        return { ...item, quantity };
+      }
+      return item;
+    });
+    setCart(updatedCart);
+    toast.success(`Item quantity updated!`);
+  };
 
-                    <div className="flex flex-col content-center justify-center text-left">
-                        <span className="text-sm text-gray-500">Cart</span>
-                        <span className="font-bold">$0</span>
-                    </div>
+  const handleRemoveFromCart = (productId: number) => {
+    const updatedCart = cart.filter((item) => item.product.id !== productId);
+    setCart(updatedCart);
+    toast.success(`Item removed from cart!`);
+  };
+
+  if (!mounted) {
+    return null; // prevent SSR/client mismatch
+  }
+
+  return (
+    <Sheet>
+      <SheetTrigger>
+        <div
+          className={cn(
+            "flex flex-row items-center justify-center text-black rounded-md hover:bg-accent cursor-pointer gap-1.5 px-3 md:px-4 py-3"
+          )}
+        >
+          <div className="relative flex items-center justify-center rounded-full ">
+            <ShoppingBasket size={28} color="black" />
+            {totalItems > 0 && (
+              <span className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary-green text-white text-xs font-bold ">
+                {totalItems}
+              </span>
+            )}
+          </div>
+          <div className="hidden md:flex flex-col justify-center text-left">
+            {totalItems > 0 ? (
+              <>
+                <span className="text-sm font-bold">
+                  {totalPrice.toFixed(2)}$
+                </span>
+              </>
+            ) : (
+              <span className="text-sm font-bold">Cart</span>
+            )}
+          </div>
+        </div>
+      </SheetTrigger>
+      <SheetContent side="right" className="w-full sm:w-[400px]">
+        <SheetHeader>
+          <SheetTitle>Your Cart</SheetTitle>
+        </SheetHeader>
+        <SheetDescription className="text-center">
+          {totalItems === 0 ? (
+            <span className="mt-8 text-gray-500">
+              Your cart is currently empty.
+            </span>
+          ) : null}
+        </SheetDescription>
+        <div>
+          {cart.map((item, index) => (
+            <div
+              key={index}
+              className="flex flex-row items-center border-b py-2 mx-4"
+            >
+              <div className="flex flex-col content-start justify-self-start mr-4">
+                <Link
+                  href={`/products/${item.product.id}`}
+                  className="font-bold hover:underline mb-1"
+                >
+                  {item.product.title}
+                </Link>
+                <div className="flex flex-row items-center border rounded-lg px-4 py-2 bg-white shadow-sm">
+                  <button
+                    className="cursor-pointer"
+                    onClick={() => {
+                      if (item.quantity > 1) {
+                        handleUpdateItemQuantity(
+                          item.product.id,
+                          item.quantity - 1
+                        );
+                      }
+                    }}
+                  >
+                    −
+                  </button>
+                  <span className="mx-4 text-lg font-medium select-none">
+                    {item.quantity}
+                  </span>
+                  <button
+                    className="cursor-pointer"
+                    onClick={() => {
+                      if (item.quantity < item.product.stock) {
+                        handleUpdateItemQuantity(
+                          item.product.id,
+                          item.quantity + 1
+                        );
+                      }
+                    }}
+                  >
+                    +
+                  </button>
                 </div>
-            </SheetTrigger>
-            <SheetContent side="right" className="w-full sm:w-[400px]">
-                <SheetHeader>
-                    <SheetTitle>Your Cart</SheetTitle>
-                </SheetHeader>
-                <SheetDescription>
-                    {cart.length === 0 ?
-                        (<p className="text-center mt-8 text-gray-500">Your cart is currently empty.</p>)
-                        : null
-                    }
-                </SheetDescription>
-                <div>
-                    {cart.map((item, index) => (
-                        <div key={index} className="flex flex-row items-center border-b py-2 mx-4">
-                            <div className="flex flex-col content-start justify-self-start mr-4">
-                                <Link href={`/products/${item.product.id}`} className="font-bold hover:underline mb-1">{item.product.title}</Link>
-                                <div className="flex flex-row items-center border rounded-lg px-4 py-2 bg-white shadow-sm">
-                                    <button className="cursor-pointer"
-                                        onClick={() => {
-                                            if (item.quantity > 1) {
-                                                handleUpdateItemQuantity(item.product.id, item.quantity - 1);
-                                            }
-                                        }}
-                                    >
-                                        −
-                                    </button>
-                                    <span className="mx-4 text-lg font-medium select-none">{item.quantity}</span>
-                                    <button className="cursor-pointer"
-                                        onClick={() => {
-                                            if (item.quantity < item.product.stock) {
-                                                handleUpdateItemQuantity(item.product.id, item.quantity + 1);
-                                            }
-                                        }}
-                                    >
-                                        +
-                                    </button>
-                                </div>
-                            </div>
-                            <div className="flex flex-col items-end justify-self-end mr-4 flex-grow">
-                                <span className="font-bold">${item.product.price * item.quantity}</span>
-                            </div>
-                            <button onClick={() => handleRemoveFromCart(item.product.id)} className="text-sm text-red-500 hover:underline ">X</button>
-                        </div>
-                    ))}
-                </div>
-                <SheetFooter>
-                    <div className="flex flex-col content-center justify-center text-center">
-                        <span className="text-sm text-gray-500">Total:</span>
-                        <span className="font-bold">$0</span>
-                        <button className="mt-4 bg-black text-white px-4 py-2 rounded-md hover:bg-[var(--primary-green)] disabled:opacity-50" disabled>
-                            Checkout
-                        </button>
-                    </div>
-                </SheetFooter>
-            </SheetContent>
-        </Sheet>
-    );
+              </div>
+              <div className="flex flex-col items-end justify-self-end mr-4 flex-grow">
+                <span className="font-bold">{totalPrice.toFixed(2)}$</span>
+              </div>
+              <button
+                onClick={() => handleRemoveFromCart(item.product.id)}
+                className="text-sm text-red-500 hover:underline "
+              >
+                X
+              </button>
+            </div>
+          ))}
+        </div>
+        <SheetFooter>
+          <div className="flex flex-col content-center justify-center text-center">
+            <span className="text-sm text-gray-500">Total:</span>
+            <span className="font-bold">
+              {totalItems ? totalPrice.toFixed(2) : 0}$
+            </span>
+            <button
+              className="mt-4 bg-black text-white px-4 py-2 rounded-md hover:bg-primary-green disabled:opacity-50"
+              disabled
+            >
+              Checkout
+            </button>
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
 }

--- a/app/src/components/header/header-mobile-menu.tsx
+++ b/app/src/components/header/header-mobile-menu.tsx
@@ -1,0 +1,76 @@
+"use client";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { NavItem } from "@/lib/types";
+import { ChevronDown, Menu } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export default function HeaderMobileMenu({ nav }: { nav: NavItem[] }) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger className="md:hidden px-2 rounded-md cursor-pointer data-[state=open]:bg-accent hover:bg-accent">
+        <Menu width={38} height={38} />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-screen rounded-t-none">
+        {nav.map((item, index) =>
+          item.subcategories ? (
+            <Collapsible key={index}>
+              <CollapsibleTrigger className="group flex justify-between items-center py-1.5 px-2 font-bold w-full text-xl cursor-pointer hover:bg-accent rounded-md">
+                <span>{item.label}</span>
+                <ChevronDown
+                  className="transition-transform duration-200 group-data-[state=open]:rotate-180"
+                  size={24}
+                />
+              </CollapsibleTrigger>
+              <CollapsibleContent className="flex flex-col py-1.5 px-4 gap-1">
+                <Link
+                  href={`/products`}
+                  className="p-2 hover:bg-accent rounded-md"
+                >
+                  All Products
+                </Link>
+                {item.subcategories.map((subItem, subIndex) => (
+                  <Link
+                    key={subIndex}
+                    href={subItem.slug}
+                    className="p-2 hover:bg-accent rounded-md"
+                  >
+                    {subItem.label}
+                  </Link>
+                ))}
+              </CollapsibleContent>
+            </Collapsible>
+          ) : (
+            <DropdownMenuItem
+              key={index}
+              asChild
+              className="data-highlighted:bg-accent cursor-pointer"
+            >
+              <Link href={item.slug} className="p-4 w-full font-bold text-xl">
+                {item.label}
+              </Link>
+            </DropdownMenuItem>
+          )
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/app/src/components/header/header-user-button.tsx
+++ b/app/src/components/header/header-user-button.tsx
@@ -1,34 +1,34 @@
-import {
-    SignInButton,
-    SignedIn,
-    SignedOut,
-    UserButton,
-} from '@clerk/nextjs'
-import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
+import { SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import { User } from "lucide-react";
 
 export default function HeaderUserButton() {
-    return (
-        <>
-            <SignedOut>
-                <SignInButton>
-                    <button className="flex flex-row justify-center items-center cursor-pointer px-4 py-2 text-black rounded-md hover:bg-gray-100 hover:underline">
-                        <Avatar className="w-12 h-12">
-                            <AvatarImage />
-                            <AvatarFallback className="bg-gray-300"></AvatarFallback>
-                        </Avatar>
-                        <span className="ml-2 font-bold text-left">Log in / Register</span>
-                    </button>
-                </SignInButton>
-            </SignedOut>
-            <SignedIn>
-                <button className="flex flex-row justify-center items-center cursor-pointer px-4 py-2 text-black rounded-md hover:bg-gray-100 hover:underline">
-                    <UserButton appearance={{
-                        elements: {
-                            userButtonAvatarBox: 'w-12 h-12',
-                        },
-                    }} />
-                </button>
-            </SignedIn>
-        </>
-    );
+  return (
+    <>
+      <SignedOut>
+        <SignInButton>
+          <div className="flex items-center">
+            <button className="flex flex-row justify-center items-center cursor-pointer px-3 md:px-4 py-3 text-black rounded-md text-sm hover:bg-accent gap-1.5">
+              <User size={28} />
+              <span className="hidden md:inline font-bold text-left">
+                Log in
+              </span>
+            </button>
+          </div>
+        </SignInButton>
+      </SignedOut>
+      <SignedIn>
+        <div className="flex items-center">
+          <UserButton
+            appearance={{
+              elements: {
+                userButtonAvatarBox: "w-8 h-8",
+                userButtonBox:
+                  "flex items-center p-2 hover:bg-[#f5f5f5] transition-all rounded-full",
+              },
+            }}
+          />
+        </div>
+      </SignedIn>
+    </>
+  );
 }

--- a/app/src/components/header/headerlink-dropdown.tsx
+++ b/app/src/components/header/headerlink-dropdown.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { HeaderLink } from "@/components/header/headerlink";
+import {
+  NavigationMenuContent,
+  NavigationMenuTrigger,
+} from "@/components/ui/navigation-menu";
+import { NavItem } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { usePathname, useRouter } from "next/navigation";
+
+type Subcategory = {
+  label: string;
+  slug: string;
+};
+
+type HeaderLinkDropdownProps = {
+  label: string;
+  href: string;
+  subcategories: Subcategory[];
+  subcategoryPath?: string;
+};
+
+export function useIsActive(item: NavItem) {
+  const pathname = usePathname();
+
+  const main = `/${item.slug.replace(/^\/?/, "")}`;
+
+  return (
+    pathname === main ||
+    item.subcategories?.some((s) => pathname.startsWith(`/${s.slug.replace(/^\/?/, "")}`)) ||
+    (main === "/products" && pathname.startsWith("/products/"))
+  );
+}
+
+export default function HeaderLinkDropdown({
+  label,
+  href,
+  subcategories,
+}: HeaderLinkDropdownProps) {
+  const router = useRouter();
+  const isActive = useIsActive({ label, slug: href, subcategories });
+
+  return (
+    <>
+      <NavigationMenuTrigger
+        className={cn(
+          "cursor-pointer text-muted-foreground font-bold",
+          isActive && " text-black"
+        )}
+        onClick={(e) => {
+          e.preventDefault(); // prevent default toggle
+          router.push(href);
+        }}
+      >
+        {label}
+      </NavigationMenuTrigger>
+      <NavigationMenuContent>
+        <ul className="grid gap-1 w-[200px]">
+          {subcategories.map((subitem, index) => (
+            <li key={index}>
+              <HeaderLink href={subitem.slug} dropdown>
+                {subitem.label}
+              </HeaderLink>
+            </li>
+          ))}
+        </ul>
+      </NavigationMenuContent>
+    </>
+  );
+}

--- a/app/src/components/header/headerlink.tsx
+++ b/app/src/components/header/headerlink.tsx
@@ -1,28 +1,35 @@
 "use client";
 import { usePathname } from "next/navigation";
-import { NavigationMenuLink } from "../ui/navigation-menu";
+import {
+  NavigationMenuLink,
+} from "../ui/navigation-menu";
 import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 export const HeaderLink = ({
   href,
+  dropdown,
   children,
   ...props
 }: {
   href: string;
+  dropdown?: boolean;
   children: React.ReactNode;
   props?: React.HTMLAttributes<HTMLElement>;
 }) => {
   const pathname = usePathname();
-  const isActive = href === pathname;
+  const isActive = href === pathname ;
 
   return (
     <NavigationMenuLink
       asChild
-      className={`text-md hover:bg-gray-300 ${
-        isActive && "underline border-dashed"
-      }`}
+      className={cn(
+        "px-4 font-bold text-muted-foreground",
+        isActive && "text-black",
+        dropdown ? (isActive ? "font-bold" : "font-medium") : "font-bold"
+      )}
     >
-      <Link href={href} className="font-bold" {...props}>
+      <Link href={href} className="" {...props}>
         {children}
       </Link>
     </NavigationMenuLink>

--- a/app/src/components/search-bar.tsx
+++ b/app/src/components/search-bar.tsx
@@ -13,15 +13,15 @@ import { redirect, RedirectType } from "next/navigation";
 
 async function SearchBar() {
   return (
-    <div
-      className={`rounded-b p-4 bg-[var(--primary-green)] flex items-center justify-evenly`}
-    >
-      <SearchForm />
-      <ul className="grow text-sm font-bold text-white justify-evenly hidden md:flex">
-        <li className="hidden xl:flex">Free shipping anywhere</li>
-        <li className="hidden lg:flex">100% Secure!</li>
-        <li className="hidden md:flex">30 Days Money Back Guarantee</li>
-      </ul>
+    <div className="full-width bg-primary-green">
+      <div className={`rounded-b py-4  flex items-center justify-evenly`}>
+        <SearchForm />
+        <ul className="grow text-sm font-semibold text-white justify-evenly hidden md:flex">
+          <li className="hidden xl:flex">Free shipping worldwide</li>
+          <li className="hidden lg:flex">Protected payments</li>
+          <li className="hidden md:flex">Easy 30-day return policy</li>
+        </ul>
+      </div>
     </div>
   );
 }
@@ -42,8 +42,11 @@ const SearchForm = () => {
     const name = data.get("productName");
 
     if (name) {
-      const category = (type) ? type.toString() : "";
-      redirect(`/products?search=${name.toString()}&categories=${category}`, RedirectType.push);
+      const category = type ? type.toString() : "";
+      redirect(
+        `/products?search=${name.toString()}&categories=${category}`,
+        RedirectType.push
+      );
     }
   }
   return (
@@ -75,12 +78,12 @@ const SearchForm = () => {
       <Input
         type="search"
         name="productName"
-        className="outline-0 focus-visible:ring-0 border-0"
+        className="outline-0 focus-visible:ring-0 border-0 text-sm"
         placeholder="Search Anything..."
       />
       <Button
         variant={"ghost"}
-        className="hover:bg-[var(--primary-green)] hover:text-white rounded-2xl h-7 cursor-pointer"
+        className="hover:bg-primary-green hover:text-white rounded-2xl h-7 cursor-pointer"
         type="submit"
       >
         <Search />

--- a/app/src/components/ui/collapsible.tsx
+++ b/app/src/components/ui/collapsible.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/app/src/components/ui/navigation-menu.tsx
+++ b/app/src/components/ui/navigation-menu.tsx
@@ -112,7 +112,7 @@ function NavigationMenuViewport({
       <NavigationMenuPrimitive.Viewport
         data-slot="navigation-menu-viewport"
         className={cn(
-          "origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--radix-navigation-menu-viewport-width)]",
+          "origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded border shadow md:w-[var(--radix-navigation-menu-viewport-width)]",
           className
         )}
         {...props}

--- a/app/src/components/ui/sheet.tsx
+++ b/app/src/components/ui/sheet.tsx
@@ -72,7 +72,7 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-5 right-5 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none cursor-pointer">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -104,3 +104,12 @@ export const contactTypeValues = contactTypes.map((t) => t.value) as [
   (typeof contactTypes)[number]["value"],
   ...(typeof contactTypes)[number]["value"][]
 ];
+
+export interface NavItem {
+  label: string;
+  slug: string;
+  subcategories?: {
+    label: string;
+    slug: string;
+  }[];
+};


### PR DESCRIPTION
- added categories dropdown navigation (desktop & mobile)
- added shadcn collapsible component
- added separate component for dropdown on desktop (components/header/headerlink-dropdown.tsx)
- broke out mobile menu navigation to a separate component (components/header/headerlink-mobile-menu.tsx)
- cart on header now updates data when adding/removing from it without page reload + cart counter added
- added bg-primary-green as tailwind variable and updated green color (might change color again)
- small adjustments on shadcn components related to header to fit our page better (change border rounded)
- added NavItem interface to types
- changes to styling & design

**Desktop**
<img width="1491" height="131" alt="image" src="https://github.com/user-attachments/assets/4edc31b7-9366-4a29-9f73-0a7c8b7936cb" />

**Desktop (logged in)** 
<img width="1384" height="130" alt="image" src="https://github.com/user-attachments/assets/fe205460-4963-4d76-af3b-f9f91735b128" />

**Mobile**
<img width="536" height="131" alt="image" src="https://github.com/user-attachments/assets/c0b35c02-7236-44e4-9554-54686a625e4b" />

**Mobile (logged in)**
<img width="535" height="131" alt="image" src="https://github.com/user-attachments/assets/35e529e4-792f-4838-a41c-11968e8f1147" />
