### PR TITLE
Rating now shows filled stars, no rating, styling adjustments on product card/stock

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -25,6 +25,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1963,6 +1964,40 @@
         "@radix-ui/react-roving-focus": "1.1.11",
         "@radix-ui/react-toggle": "1.1.10",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/app/src/components/product-card.tsx
+++ b/app/src/components/product-card.tsx
@@ -3,33 +3,104 @@ import Image from "next/image";
 import ProductPrice from "./product-price";
 import StockStatus from "./stock-status";
 import Link from "next/link";
+import { Star, StarHalf } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 export default function ProductCard({ product }: { product: ThinProduct }) {
   return (
     <article className="contents">
       <Link
         href={`/products/${product.id}`}
-        className="grid grid-rows-subgrid gap-1 row-span-5 py-2 px-4 border border-white focus-within:border-gray-300 hover:border-gray-300 "
+        className="grid grid-rows-subgrid gap-1 row-span-4 focus-within:border-gray-300 hover:border-gray-100 transition-colors rounded group"
       >
-        <div className="flex flex-col items-center gap-3">
+        <div className="relative flex justify-center items-center bg-accent rounded">
+          {product.discountPercentage > 0 && (
+            <div className="absolute top-2 left-2">
+              <Badge
+                variant="destructive"
+                className="rounded px-2 py-1 text-xs font-semibold"
+              >
+                -{Math.round(product.discountPercentage)}%
+              </Badge>
+            </div>
+          )}
           <Image
             src={product.thumbnail ?? "/placeholder-image.svg"}
             alt={product.title}
-            className="w-full object-cover rounded"
+            className="w-full object-cover rounded p-4 group-hover:scale-[1.02] transition-all"
             priority
             width={300}
             height={300}
           />
-          <p className="text-sm text-gray-500 py-2">{product.rating} ⭐</p>
         </div>
-        <h2 className="text-md font-semibold">{product.title}</h2>
-
-        <ProductPrice
-          price={product.price}
-          discountPercentage={product.discountPercentage}
-        />
-        <StockStatus amount={product.stock} />
+        <div className="flex justify-between items-center px-2 py-1">
+          <Rating rating={product.rating} />
+          <StockStatus amount={product.stock} showTooltip/>
+        </div>
+        <h2 className="text-md font-semibold px-2 py-1">{product.title}</h2>
+        <div className="px-2 pt-1 pb-3">
+          <ProductPrice
+            price={product.price}
+            discountPercentage={product.discountPercentage}
+          />
+        </div>
       </Link>
     </article>
+  );
+}
+
+function Rating({ rating }: { rating: number }) {
+  const safeRating = Math.max(0, Math.min(5, rating));
+
+  if (safeRating === 0) {
+    return <span className="text-xs text-muted-foreground">No Rating</span>;
+  }
+
+  const fullStars = Math.floor(safeRating);
+  const hasHalf = safeRating % 1 >= 0.5;
+  const emptyStars = 5 - fullStars - (hasHalf ? 1 : 0);
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex items-center gap-0.5 text-yellow-500  py-2">
+            {/* full stars */}
+            {[...Array(fullStars)].map((_, i) => (
+              <Star key={`full-${i}`} size={16} fill="currentColor" strokeWidth={0} />
+            ))}
+
+            {/* half star with background */}
+            {hasHalf && (
+              <div className="relative w-4 h-4">
+                {/* empty star behind */}
+                <Star
+                  size={16}
+                  fill="none"
+                  strokeWidth={1.5}
+                  className="absolute top-0 left-0"
+                />
+                {/* half star on top */}
+                <StarHalf
+                  size={16}
+                  fill="currentColor"
+                  strokeWidth={0}
+                  className="absolute top-0 left-0"
+                />
+              </div>
+            )}
+
+            {/* empty stars */}
+            {[...Array(emptyStars)].map((_, i) => (
+              <Star key={`empty-${i}`} size={16} fill="none" strokeWidth={1.5} />
+            ))}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{safeRating.toFixed(1)} / 5</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/app/src/components/product-card.tsx
+++ b/app/src/components/product-card.tsx
@@ -5,30 +5,33 @@ import StockStatus from "./stock-status";
 import Link from "next/link";
 import { Star, StarHalf } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export default function ProductCard({ product }: { product: ThinProduct }) {
   return (
     <article className="contents">
       <Link
         href={`/products/${product.id}`}
-        className="grid grid-rows-subgrid gap-1 row-span-4 focus-within:border-gray-300 hover:border-gray-100 transition-colors rounded group"
+        className="grid grid-rows-subgrid gap-1 row-span-4 focus-within:border-gray-300 transition-colors rounded group"
       >
         <div className="relative flex justify-center items-center bg-accent rounded">
           {product.discountPercentage > 0 && (
-            <div className="absolute top-2 left-2">
-              <Badge
-                variant="destructive"
-                className="rounded px-2 py-1 text-xs font-semibold"
-              >
-                -{Math.round(product.discountPercentage)}%
-              </Badge>
-            </div>
+            <Badge
+              variant="destructive"
+              className="rounded px-2 py-1 text-xs font-semibold absolute top-2 left-2 z-50"
+            >
+              -{Math.round(product.discountPercentage)}%
+            </Badge>
           )}
           <Image
             src={product.thumbnail ?? "/placeholder-image.svg"}
             alt={product.title}
-            className="w-full object-cover rounded p-4 group-hover:scale-[1.02] transition-all"
+            className="w-full object-cover rounded p-4 group-hover:scale-[1.02] transition-transform"
             priority
             width={300}
             height={300}
@@ -36,7 +39,7 @@ export default function ProductCard({ product }: { product: ThinProduct }) {
         </div>
         <div className="flex justify-between items-center px-2 py-1">
           <Rating rating={product.rating} />
-          <StockStatus amount={product.stock} showTooltip/>
+          <StockStatus amount={product.stock} showTooltip />
         </div>
         <h2 className="text-md font-semibold px-2 py-1">{product.title}</h2>
         <div className="px-2 pt-1 pb-3">
@@ -68,7 +71,12 @@ function Rating({ rating }: { rating: number }) {
           <div className="flex items-center gap-0.5 text-yellow-500  py-2">
             {/* full stars */}
             {[...Array(fullStars)].map((_, i) => (
-              <Star key={`full-${i}`} size={16} fill="currentColor" strokeWidth={0} />
+              <Star
+                key={`full-${i}`}
+                size={16}
+                fill="currentColor"
+                strokeWidth={0}
+              />
             ))}
 
             {/* half star with background */}
@@ -93,7 +101,12 @@ function Rating({ rating }: { rating: number }) {
 
             {/* empty stars */}
             {[...Array(emptyStars)].map((_, i) => (
-              <Star key={`empty-${i}`} size={16} fill="none" strokeWidth={1.5} />
+              <Star
+                key={`empty-${i}`}
+                size={16}
+                fill="none"
+                strokeWidth={1.5}
+              />
             ))}
           </div>
         </TooltipTrigger>

--- a/app/src/components/product-price.tsx
+++ b/app/src/components/product-price.tsx
@@ -1,14 +1,31 @@
-export default function ProductPrice({ price, discountPercentage }: { price: number, discountPercentage?: number }) {
-    const discountedPrice = discountPercentage
-        ? + (price - (price * discountPercentage / 100)).toFixed(2)
-        : price;
+import { cn } from "@/lib/utils";
 
-    return (
-        <div className="flex flex-row gap-2 items-center justify-start py-1">
-            <p className={`text-lg font-bold ${discountPercentage ? " text-red-600" : ""}`}>${discountedPrice}</p>
-            {discountPercentage && (
-                <p className="text-sm text-gray-500 line-through">${price}</p>
-            )}
-        </div>
-    );
+export default function ProductPrice({
+  price,
+  discountPercentage,
+}: {
+  price: number;
+  discountPercentage?: number;
+}) {
+  const discountedPrice = discountPercentage
+    ? +(price - (price * discountPercentage) / 100).toFixed(2)
+    : price;
+
+  return (
+    <div className={"flex flex-row gap-2 items-center justify-start"}>
+      <p
+        className={cn(
+          "text-lg font-bold",
+          discountPercentage ? "text-red-600" : ""
+        )}
+      >
+        ${discountedPrice}
+      </p>
+      {discountPercentage && (
+        <p className="text-sm text-muted-foreground line-through">
+          ${price}
+        </p>
+      )}
+    </div>
+  );
 }

--- a/app/src/components/products/product-info.tsx
+++ b/app/src/components/products/product-info.tsx
@@ -60,7 +60,7 @@ export default function ProductInfo({
           <Separator />
 
           <div className="flex flex-col mt-2 mb-2">
-            <StockStatus amount={product.stock} />
+            <StockStatus amount={product.stock} showLabel />
             <AddToCartButton product={product} />
 
             <p className="text-sm mb-2">Guaranteed Safe Checkout</p>

--- a/app/src/components/stock-status.tsx
+++ b/app/src/components/stock-status.tsx
@@ -1,42 +1,72 @@
-export default function StockStatus({ amount }: { amount: number }) {
-    return (
-        <p className="text-sm text-gray-500 flex items-center gap-2">
-            {amount > 7 ? (
-                <span className="inline-flex items-center">
-                    <span className="w-4 h-4 bg-green-500 rounded-full flex items-center justify-center mr-1">
-                        <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 16 16">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M4 8l3 3 5-5" />
-                        </svg>
-                    </span>
-                    In Stock
-                </span>
-            ) : amount <= 7 && amount > 0 ? (
-                <span className="inline-flex items-center">
-                    <span className="w-4 h-4 bg-yellow-500 rounded-full flex items-center justify-center mr-1">
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 24 24"
-                            width="24" height="24"
-                            role="img"
-                            aria-labelledby="exclTitle exclDesc"
-                            className="w-3 h-3 text-white"
-                        >
-                            <rect x="11" y="6" width="2" height="8" rx="1" fill="none" stroke="currentColor" />
-                            <circle cx="12" cy="17" r="1.2" fill="none" stroke="currentColor" />
-                        </svg>
-                    </span>
-                    Low Stock
-                </span>
-            ) : (
-                <span className="inline-flex items-center">
-                    <span className="w-4 h-4 bg-red-500 rounded-full flex items-center justify-center mr-1">
-                        <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 16 16">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M5 5l6 6M11 5l-6 6" />
-                        </svg>
-                    </span>
-                    Out of Stock
-                </span>
-            )}
-        </p>
-    );
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { Check, X, Minus } from "lucide-react";
+
+interface StockStatusProps {
+  amount: number;
+  showLabel?: boolean;
+  showTooltip?: boolean;
+}
+
+export default function StockStatus({
+  amount,
+  showLabel,
+  showTooltip,
+}: StockStatusProps) {
+  let bgColor: string;
+  let Icon: typeof Check;
+  let label: string;
+
+  if (amount > 7) {
+    bgColor = "bg-green-500";
+    Icon = Check;
+    label = "In Stock";
+  } else if (amount <= 7 && amount > 0) {
+    bgColor = "bg-yellow-500";
+    Icon = Minus;
+    label = "Low Stock";
+  } else {
+    bgColor = "bg-red-500";
+    Icon = X;
+    label = "Out of Stock";
+  }
+
+  const content = (
+    <span className="inline-flex items-center">
+      <span
+        className={cn(
+          "w-4 h-4 rounded-full flex items-center justify-center",
+          showLabel && "mr-1",
+          bgColor
+        )}
+      >
+        <Icon className="w-3 h-3 text-white" strokeWidth={2} />
+      </span>
+      {showLabel && label}
+    </span>
+  );
+
+  return (
+    <div className="text-sm text-gray-500 flex items-center p-1">
+      {showTooltip ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>{content}</TooltipTrigger>
+            <TooltipContent>
+              <p>
+                {label} {amount > 0 ? `(${amount} left)` : ""}
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        content
+      )}
+    </div>
+  );
 }

--- a/app/src/components/ui/tooltip.tsx
+++ b/app/src/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }


### PR DESCRIPTION
- shows filled stars for rating, no rating if rating = 0
- adds tooltip to rating/stock (shadcn tooltip, remember to npm i)
- some styling adjustments to product cards

<img width="292" height="404" alt="image" src="https://github.com/user-attachments/assets/89945bf9-cda5-48f0-9abe-f8ae680aedfb" />
<img width="244" height="428" alt="image" src="https://github.com/user-attachments/assets/e717e35f-3a1a-4439-bc59-c4baa9e2cf91" />
